### PR TITLE
Add "Bake to Scene"

### DIFF
--- a/game/addons/nexus_vertex_painter/painter_dock.gd
+++ b/game/addons/nexus_vertex_painter/painter_dock.gd
@@ -8,6 +8,7 @@ signal clear_requested(active_channels)
 signal procedural_requested(type, settings)
 signal texture_changed(texture)
 signal bake_requested()
+signal bake_to_scene_requested()
 signal revert_requested()
 
 # --- UI REFERENCES (Unique Names) ---
@@ -61,6 +62,7 @@ signal revert_requested()
 
 # Production
 @onready var btn_bake: Button = %Bake_Button
+@onready var btn_bake_scene: Button = %BakeScene_Button
 @onready var btn_revert: Button = %Revert_Button
 
 # Internal State
@@ -150,6 +152,8 @@ func _ready() -> void:
 	# 9. Setup Bake & Revert
 	if not btn_bake.pressed.is_connected(_on_bake_pressed):
 		btn_bake.pressed.connect(_on_bake_pressed)
+	if not btn_bake_scene.pressed.is_connected(_on_bake_to_scene_pressed):
+		btn_bake_scene.pressed.connect(_on_bake_to_scene_pressed)
 	
 	if not btn_revert.pressed.is_connected(_on_revert_pressed):
 		btn_revert.pressed.connect(_on_revert_pressed)
@@ -204,6 +208,7 @@ func _setup_tooltips() -> void:
 	if btn_proc_slope: btn_proc_slope.tooltip_text = "Procedural: paint sloped surfaces"
 	if btn_proc_noise: btn_proc_noise.tooltip_text = "Procedural: apply noise pattern"
 	if btn_bake: btn_bake.tooltip_text = "Bake vertex colors into mesh file"
+	if btn_bake_scene: btn_bake_scene.tooltip_text = "Bake vertex colors into the ancestor scene file"
 	if btn_revert: btn_revert.tooltip_text = "Revert to original mesh (irreversible)"
 	if size_slider: size_slider.tooltip_text = "Brush size. Ctrl+RMB drag: vertical"
 	if falloff_slider: falloff_slider.tooltip_text = "Brush falloff. Shift+RMB drag: vertical"
@@ -298,6 +303,8 @@ func _on_texture_changed(tex: Texture2D):
 	emit_signal("texture_changed", tex)
 func _on_bake_pressed():
 	emit_signal("bake_requested")
+func _on_bake_to_scene_pressed():
+	emit_signal("bake_to_scene_requested")
 func _on_revert_pressed():
 	emit_signal("revert_requested")
 

--- a/game/addons/nexus_vertex_painter/painter_dock.tscn
+++ b/game/addons/nexus_vertex_painter/painter_dock.tscn
@@ -418,6 +418,12 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "Bake to Mesh"
 
+[node name="BakeScene_Button" type="Button" parent="ProductionContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Bake to Scene"
+
 [node name="Revert_Button" type="Button" parent="ProductionContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2

--- a/game/addons/nexus_vertex_painter/plugin.gd
+++ b/game/addons/nexus_vertex_painter/plugin.gd
@@ -1435,10 +1435,15 @@ func _bake_vertex_color_data_in_scene(scene_root: Node) -> bool:
 	return baked_any
 
 func _save_scene_root_to_path(scene_root: Node, path: String) -> bool:
+	var save_root := scene_root.duplicate()
+	var original_transform := scene_root.property_get_revert(&"transform")
+	if original_transform:
+		save_root.transform = original_transform
+
 	var lower_path = path.to_lower()
 	if lower_path.ends_with(".tscn") or lower_path.ends_with(".scn"):
 		var packed_scene := PackedScene.new()
-		var pack_error := packed_scene.pack(scene_root)
+		var pack_error := packed_scene.pack(save_root)
 		if pack_error != OK:
 			VertexPainterLog.error("Failed to pack scene root for saving: " + error_string(pack_error))
 			return false
@@ -1452,7 +1457,7 @@ func _save_scene_root_to_path(scene_root: Node, path: String) -> bool:
 		var gltf_document := GLTFDocument.new()
 		var gltf_state := GLTFState.new()
 		gltf_state.base_path = path.get_base_dir()
-		var append_error := gltf_document.append_from_scene(scene_root, gltf_state)
+		var append_error := gltf_document.append_from_scene(save_root, gltf_state)
 		if append_error != OK:
 			VertexPainterLog.error("Failed to convert scene to glTF: " + error_string(append_error))
 			return false

--- a/game/addons/nexus_vertex_painter/plugin.gd
+++ b/game/addons/nexus_vertex_painter/plugin.gd
@@ -7,6 +7,7 @@ const LARGE_MESH_VERTEX_WARN := 500000
 const VERTEX_COLOR_DATA_SCRIPT := "res://addons/nexus_vertex_painter/vertex_color_data.gd"
 
 # --- UI & REFERENCES ---
+var dock: EditorDock
 var dock_instance: Control
 var btn_mode: Button
 var shared_brush_material: ShaderMaterial 
@@ -48,14 +49,30 @@ var revert_confirm_dialog: ConfirmationDialog
 
 
 func _enter_tree():
+	# Create new EditorDock
+	dock = EditorDock.new()
+	dock.title = "Vertex Painter"
+	dock.default_slot = EditorDock.DOCK_SLOT_RIGHT_UL
+	
+	# Setup dock icon
+	var editor_base = get_editor_interface().get_base_control()
+	if editor_base.has_theme_icon("Edit", "EditorIcons"):
+		dock.dock_icon = editor_base.get_theme_icon("Edit", "EditorIcons")
+	
+	# Instantiate dock content and add it to the EditorDock
 	dock_instance = DOCK_SCENE.instantiate()
-	add_control_to_dock(DOCK_SLOT_RIGHT_UL, dock_instance)
+	dock.add_child(dock_instance)
+	
+	# Add dock to the editor
+	add_dock(dock)
+	
 	dock_instance.fill_requested.connect(_on_fill_requested)
 	dock_instance.clear_requested.connect(_on_clear_requested)
 	dock_instance.settings_changed.connect(_on_settings_changed)
 	dock_instance.texture_changed.connect(_on_texture_changed)
 	dock_instance.procedural_requested.connect(_on_procedural_requested)
 	dock_instance.bake_requested.connect(_on_bake_requested)
+	dock_instance.bake_to_scene_requested.connect(_on_bake_to_scene_requested)
 	dock_instance.revert_requested.connect(_on_revert_requested)
 	dock_instance.set_ui_active(false)
 	
@@ -80,7 +97,6 @@ func _enter_tree():
 	file_dialog.file_selected.connect(_on_bake_file_selected)
 	get_editor_interface().get_base_control().add_child(file_dialog)
 	
-	var editor_base = get_editor_interface().get_base_control()
 	if editor_base.has_theme_icon("Edit", "EditorIcons"):
 		btn_mode.icon = editor_base.get_theme_icon("Edit", "EditorIcons")
 	
@@ -136,9 +152,9 @@ func _exit_tree():
 	if file_dialog:
 		file_dialog.queue_free()
 	
-	if dock_instance:
-		remove_control_from_docks(dock_instance)
-		dock_instance.free()
+	if dock:
+		remove_dock(dock)
+		dock.queue_free()
 	
 	if btn_mode:
 		remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, btn_mode)
@@ -160,6 +176,7 @@ func _on_mode_toggled(pressed: bool):
 		is_adjusting_brush = false
 		dock_instance.set_selection_empty(false)
 	else:
+		dock.make_visible()
 		_refresh_selection_and_colliders()
 		_update_brush_image_cache()
 		dock_instance.set_selection_empty(selected_meshes.is_empty())
@@ -187,9 +204,13 @@ func _on_selection_changed():
 # --- SELECTION & LOCKING ---
 
 func _refresh_selection_and_colliders():
-	var selection = get_editor_interface().get_selection().get_selected_nodes()
+	var selection := get_editor_interface().get_selection().get_selected_nodes()
 	var new_mesh_list: Array[MeshInstance3D] = []
-	
+
+	selection = selection.filter(func(node):
+		return is_instance_valid(node)
+	)
+
 	for node in selection:
 		if node is MeshInstance3D:
 			new_mesh_list.append(node)
@@ -219,7 +240,10 @@ func _refresh_selection_and_colliders():
 			_create_collider_for(mesh)
 	
 	for i in range(temp_colliders.size() - 1, -1, -1):
-		var node = temp_colliders[i]
+		var node := temp_colliders[i]
+		if not is_instance_valid(node):
+			temp_colliders.remove_at(i)
+			continue
 		if not is_instance_valid(node.get_parent()) or node.get_parent() not in new_mesh_list:
 			node.queue_free()
 			temp_colliders.remove_at(i)
@@ -1049,6 +1073,8 @@ func _init_shared_brush_material():
 
 func _update_shader_debug_view():
 	for mesh in selected_meshes:
+		if not is_instance_valid(mesh):
+			continue
 		var mat = mesh.get_active_material(0) as ShaderMaterial
 		if mat:
 			mat.set_shader_parameter("active_layer_view", 0)
@@ -1283,13 +1309,52 @@ func _on_bake_requested():
 	file_dialog.current_file = original_name + "_painted.res"
 	file_dialog.popup_centered_ratio(0.5)
 
+func _on_bake_to_scene_requested():
+	if selected_meshes.is_empty():
+		VertexPainterLog.warn("No mesh selected to bake. Please select a MeshInstance3D.")
+		return
+
+	var mesh_instance = selected_meshes[0]
+	if not mesh_instance.mesh:
+		VertexPainterLog.warn("Selected mesh has no mesh resource. Cannot bake.")
+		return
+
+	var scene_root := _get_ancestor_scene_root(mesh_instance)
+	if not scene_root:
+		VertexPainterLog.warn("Selected mesh is not part of a saved scene. Open a saved .tscn, .scn, .gltf, or .glb scene to bake to scene file.")
+		return
+	
+	var current_scene_root := get_editor_interface().get_edited_scene_root()
+
+	var scene_path := scene_root.scene_file_path
+	if scene_path == "":
+		VertexPainterLog.warn("Ancestor scene has no file path. Save the scene before baking to file.")
+		return
+
+	if not _bake_vertex_color_data_in_scene(scene_root):
+		VertexPainterLog.warn("Bake to Scene aborted because no mesh data could be baked.")
+		return
+
+	_on_mode_toggled(false)
+
+	if not _save_scene_root_to_path(scene_root, scene_path):
+		VertexPainterLog.error("Failed to save scene to " + scene_path)
+		return
+
+	get_editor_interface().get_resource_filesystem().reimport_files([scene_path])
+	get_editor_interface().reload_scene_from_path(current_scene_root.scene_file_path)
+
+	_on_mode_toggled(true)
+
+	print_rich("[color=cyan]Baked vertex colors into scene file: %s.[/color]" % scene_path)
+
 func _on_bake_file_selected(path: String):
 	if selected_meshes.is_empty(): return
 	var mesh_instance = selected_meshes[0]
 	if not mesh_instance.mesh:
 		VertexPainterLog.error("Cannot bake: selected mesh has no mesh resource.")
 		return
-	var data_node = _get_or_create_data_node(mesh_instance)
+	var data_node := _get_or_create_data_node(mesh_instance)
 	
 	# Ensure colors are applied to the mesh instance currently
 	data_node._apply_colors()
@@ -1326,6 +1391,79 @@ func _on_bake_file_selected(path: String):
 	# Refresh UI state and clear preview overlays (baked mesh replaced original)
 	_clear_preview_overlays(false)
 	_refresh_selection_and_colliders()
+
+func _get_ancestor_scene_root(node: Node) -> Node:
+	var current := node
+	while current:
+		if current.scene_file_path != "":
+			return current
+		current = current.get_parent()
+	return get_editor_interface().get_edited_scene_root()
+
+func _bake_vertex_color_data_in_scene(scene_root: Node) -> bool:
+	if not scene_root:
+		return false
+
+	var data_nodes: Array = scene_root.find_children("*", "VertexColorData", true, false)
+	if data_nodes.is_empty():
+		return true
+
+	var baked_any := false
+	var nodes_to_remove: Array[VertexColorData] = []
+	for data_node in data_nodes:
+		if not is_instance_valid(data_node):
+			continue
+		var mesh_instance := data_node.get_parent() as MeshInstance3D
+		if not mesh_instance or not mesh_instance.mesh:
+			continue
+		data_node._apply_colors()
+		mesh_instance.mesh = mesh_instance.mesh.duplicate()
+		undo_snapshots.erase(data_node)
+		nodes_to_remove.append(data_node)
+		baked_any = true
+
+	if baked_any:
+		get_undo_redo().clear_history(false)
+		for data_node in nodes_to_remove:
+			if not is_instance_valid(data_node):
+				continue
+			var parent := data_node.get_parent()
+			if parent:
+				parent.remove_child(data_node)
+			data_node.free()
+
+	return baked_any
+
+func _save_scene_root_to_path(scene_root: Node, path: String) -> bool:
+	var lower_path = path.to_lower()
+	if lower_path.ends_with(".tscn") or lower_path.ends_with(".scn"):
+		var packed_scene := PackedScene.new()
+		var pack_error := packed_scene.pack(scene_root)
+		if pack_error != OK:
+			VertexPainterLog.error("Failed to pack scene root for saving: " + error_string(pack_error))
+			return false
+		var save_error := ResourceSaver.save(packed_scene, path)
+		if save_error != OK:
+			VertexPainterLog.error("Failed to save packed scene: " + error_string(save_error))
+			return false
+		return true
+
+	if lower_path.ends_with(".gltf") or lower_path.ends_with(".glb"):
+		var gltf_document := GLTFDocument.new()
+		var gltf_state := GLTFState.new()
+		gltf_state.base_path = path.get_base_dir()
+		var append_error := gltf_document.append_from_scene(scene_root, gltf_state)
+		if append_error != OK:
+			VertexPainterLog.error("Failed to convert scene to glTF: " + error_string(append_error))
+			return false
+		var write_error := gltf_document.write_to_filesystem(gltf_state, path)
+		if write_error != OK:
+			VertexPainterLog.error("Failed to write glTF scene: " + error_string(write_error))
+			return false
+		return true
+
+	VertexPainterLog.error("Unsupported scene file type for Bake to Scene: " + path)
+	return false
 
 # --- REVERT LOGIC ---
 


### PR DESCRIPTION
One of our artists (who I believe was in touch with you recently ^^) needed this feature:

"Bake to Scene" is a new button that allows users to directly bake and write changes to the original scene file (`.tscn`,`.scn`,`.gltf` or `.glb`).

It works by finding the painted MeshInstance's closest ancestor with a `scene_file_path` (usually either the current edited scene root or a Node with "Editable Children" enabled) and writing to said file path using either the `ResourceSaver` or `GLTFDocument` class. After the operation, the scene file is reimported and the current scene reloaded.

While testing the feature, I ran into a couple of crashes. Turns out `selection`, `temp_colliders` and `selected_meshes` could hold onto previously freed Nodes when a Scene was closed in the Editor. I added a couple of `is_instance_valid()` checks, which seem to have fixed the issue.

Additionally, `add_control_to_dock` was deprecated in favor of `_add_dock` and `EditorDock`, so I migrated the dock, which also allowed making it show up when the Vertex Paint mode is enabled.

Feel free to toss out anything you don't like :)

(Sorry for shoving it into one commit 😅)